### PR TITLE
refactor: rename module to rules_ghdl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "bazel_rules_ghdl",
+    name = "rules_ghdl",
     version = "0.0.0",
 )
 

--- a/bin/ghdl.sh
+++ b/bin/ghdl.sh
@@ -13,7 +13,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 # --- end runfiles.bash initialization v3 ---
 
 # For some reason rlocation gives up if it doesn't find the repo.
-_rootfs_dir="$(rlocation ${TEST_WORKSPACE:-bazel_rules_ghdl}/image/rootfs)"
+_rootfs_dir="$(rlocation ${TEST_WORKSPACE:-rules_ghdl}/image/rootfs)"
 if [[ ${_rootfs_dir} == "" ]]; then
   echo "could not find rootfs: ${_rootfs_dir}"
   exit 1

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_rules_ghdl//:rules.bzl", "ghdl_library", "ghdl_verilog")
+load("@rules_ghdl//:rules.bzl", "ghdl_library", "ghdl_verilog")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 ghdl_library(

--- a/integration/MODULE.bazel
+++ b/integration/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "bazel_rules_ghdl_integration",
+    name = "rules_ghdl_integration",
     version = "0.0.0",
 )
 
@@ -7,8 +7,8 @@ bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gotopt2", version = "2.3.3")
 bazel_dep(name = "bazel_rules_bid", version = "1.4.0")
-bazel_dep(name = "bazel_rules_ghdl", version = "0.0.0")
+bazel_dep(name = "rules_ghdl", version = "0.0.0")
 local_path_override(
-    module_name = "bazel_rules_ghdl",
+    module_name = "rules_ghdl",
     path = "../",
 )


### PR DESCRIPTION
Rename module bazel_rules_ghdl to rules_ghdl.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: check out repo bazel_rules_ghdl, and rename the module to rules_ghdl. change all places where this is necessary
