### PR TITLE
docs(ghdl): update README.md and initialize GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,93 @@
+# Instructions
+
+Firstly, read README.md to understand how to build and what the purpose of
+things is.
+
+## Core Rules
+
+- **Bazel 9.1.0 Compatibility**: This project uses Bazel 9.1.0. Ensure all
+  changes are compatible with this version.
+- **Go Commands**: Do not run `go` directly. Always use `bazel run
+  @rules_go//go -- <args>`.
+- **Go Scripting**: Use Go for scripting tasks instead of Python. Use the
+  library `github.com/bitfield/script` for shell-like commands.
+  - **Commands:**
+    - **NEVER** run `go` directly. Always use `bazel run @rules_go//go -- <args>`.
+    - Use `bazel run //:gazelle` to update build rules.
+    - Use `bazel mod tidy` to update `MODULE.bazel`.
+    - Build: `bazel build //...`
+    - Test: `bazel test //...`
+- **DO NOT** downgrade dependencies. If a downgrade is needed, stop and ask the
+  user for permission.
+- To manipulate bazel BUILD files with buildozer, use:
+  `bazel run @buildozer -- ARGS`
+
+## Modification Restrictions
+
+Never auto-modify the following files:
+* Anything in `//tools/bazel`
+* Any dotfile (except when specifically instructed).
+* Any `*.lock` files.
+* Any `*.nix` files.
+
+Unless otherwise instructed, only apply maintenance tasks to files in the git
+index, or uncommitted files, to avoid redoing work on files that are already
+committed to git.
+
+## Formatting
+
+**Do not run buildifier** on VHDL files, as it will mess up the VHDL file ordering.
+
+## License Maintenance
+
+When maintaining the license files do not modify the following:
+
+* Files matching `*.gtkw`.
+* Files under the directory `//third_party`.
+* Any files with filenames beginning with a dot.
+
+For all source files and all BUILD files, verify that they have a license
+reference at the beginning of the file.
+
+If a file does not have a license reference, add the SPDX license tag for
+Apache 2.0 header, appropriately enclosed in comments for the source file.
+
+## BCR Publishing
+
+- Follow standard Bazel Central Registry (BCR) publishing procedures.
+- Update the `version` parameter in the `module` statement in `MODULE.bazel`
+  when releasing.
+- Add `@bazel-io skip_check unstable_url` at the end of the PR description for
+  BCR.
+
+# Build and test
+
+* To test, test both the "main" repo and the "integration" repo.
+  * To test main repo:
+    `bazel build //... && bazel test //...`
+  * To test integration repo:
+    `cd integration && bazel build //... && bazel test //...`
+
+## Source control guidance
+
+- Prefer rebase over merge: `git pull origin main --rebase`.
+- PRs should be created against the `main` branch.
+- Before creating PRs, rebase from main, and fix any conflicts.
+- When resolving conflicts, use the `--no-edit` git option to prevent
+  interactive editor invocations.
+
+## Engineering Standards
+
+- **Error Handling:** Never ignore errors. Propagate them with context or log
+  them explicitly.
+- Every feature MUST have unit tests.
+- Large features MUST have integration tests.
+- After every feature implementation, build and run tests to verify
+  functionality and prevent regressions.
+- **Feature Documentation:** Every new feature must be described in a Markdown
+  report placed in the `//doc` directory. Additionally, the new report must be
+  linked within the documentation index at `//doc/README.md`.
+
+## Workspace Conventions
+
+- Use "Conventional Commits 1.0.0" for commit messages.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bazel rules for ghdl
+# Bazel rules for GHDL
 
 [![Test status](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/test.yml/badge.svg)](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/test.yml)
 [![Publish BCR status](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/publish-bcr.yml/badge.svg)](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/publish-bcr.yml)
@@ -6,7 +6,7 @@
 [![Tag and Release status](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/tag-and-release.yml/badge.svg)](https://github.com/filmil/bazel_rules_ghdl/actions/workflows/tag-and-release.yml)
 
 This repository contains a [`bazel`][bb] rule set for running [`ghdl`][gg], the
-VHDL simulator and synthesizer
+VHDL simulator and synthesizer.
 
 [bb]: https://bazel.build
 [gg]: https://github.com/ghdl/ghdl
@@ -24,29 +24,75 @@ Everything else will be downloaded for use the first time you run the build.
 
 See [rules.md](rules.md) for the generated rule documentation.
 
+## Architecture & Integration with `rules_vhdl`
+
+This workspace is fully integrated with the foundational [`rules_vhdl`][rv]
+graph module. VHDL dependency graphs are declared once using `vhdl_library`, and
+the GHDL backend translates this metadata into compilation, elaboration, and test
+execution steps.
+
+[rv]: https://github.com/hw-bzl/rules_vhdl
+
+- **`vhdl_library`** (from `@rules_vhdl`): Groups VHDL source files and
+  describes dependencies. It generates a transitive `VHDLLibraryProvider`.
+- **`ghdl_analyze`**: Consumes `vhdl_library` targets and compiles VHDL files
+  using `ghdl -a` into an isolated, hermetic GHDL object directory.
+- **`ghdl_elaborate`**: Takes compiled GHDL object targets and elaborates them
+  using `ghdl -e`.
+- **`ghdl_test`**: Groups compilation, elaboration, and execution into an
+  executable test rule using `ghdl -r` inside a sandboxed test runner.
+
 ## Hermeticity
 
-This rule set is hermetic. All dependencies are set up automatically by `bazel`.
+This rule set is completely hermetic. All dependencies are set up automatically
+by `bazel`. In addition, `ghdl_analyze` automatically rewrites absolute sandbox
+execution paths inside generated `.cf` library indexes into relative paths,
+enabling robust compilation across different sandboxed actions.
 
 ## Examples
 
 In general, see [integration/](integration/) for example use.
 
-The module is available through my bazel registry at https://github.com/filmil/bazel-registry.
+The module is available through my bazel registry at
+https://github.com/filmil/bazel-registry.
 
-### `ghdl_verilog`
+### Declaring a VHDL Library and Compile Target
 
-Use GDHL to convert a vhdl file to verilog.  The build process will build an
-intermediate result of a single VHDL library as well.
+```starlark
+load("@rules_vhdl//vhdl:defs.bzl", "vhdl_library")
+load("@rules_ghdl//:rules.bzl", "ghdl_analyze")
 
+# 1. Group the sources
+vhdl_library(
+    name = "lib_src",
+    srcs = ["hello.vhdl"],
+    library = "lib",
+)
+
+# 2. Analyze the library
+ghdl_analyze(
+    name = "lib",
+    library = ":lib_src",
+    args = ["--ieee=synopsys"],
+)
 ```
-cd integration && bazel build //... && cat bazel-bin/verilog/lib.v
+
+### Running VHDL Tests
+
+```starlark
+load("@rules_ghdl//:rules.bzl", "ghdl_test")
+
+ghdl_test(
+    name = "hello_world_test",
+    srcs = ["test.vhdl"],
+    entity = "hello_world",
+)
 ```
 
-To see how it builds a library, run this:
+To run tests in the `integration/` directory:
 
-```
-cd integration && bazel build //:lib
+```bash
+cd integration && bazel test //...
 ```
 
 ## Notes
@@ -58,5 +104,3 @@ cd integration && bazel build //:lib
 
 * https://github.com/solsjo/rules_ghdl: an alternative rule set, which is not
   hermetic.
-
-


### PR DESCRIPTION
This pull request reworks the `README.md` to cleanly summarize the newly integrated `@rules_vhdl` modular VHDL compilation pipeline, and initializes `GEMINI.md` with standard settings, git interaction rules, and engineering standards.

### Summary of Changes:
- **README Rework**: Rewrote `README.md` to represent the updated rule names (`ghdl_analyze`, `ghdl_elaborate`, `ghdl_test`) and show usage examples for the source-metadata graph model. Reflowed the file to 80 characters maximum line width.
- **GEMINI.md Initialization**: Initialized `GEMINI.md` utilizing the standard project rules, workspace conventions, testing guidelines, and repository constraints derived from our sister project `rules_nvc`.

This pull request has been created by an automated coding assistant, with
human supervision.

Exact prompt:
rework README.md to better represent the summary of the document. Also initialize GEMINI.md with my typical settings