### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "ghdl", version = "6.0.0.bcr.2")
 bazel_dep(name = "platforms", version = "1.1.0")
-bazel_dep(name = "rules_vhdl", version = "0.2.0")
+bazel_dep(name = "rules_vhdl", version = "0.3.0")
 
 # Documentation generation dependencies
 bazel_dep(name = "gazelle", version = "0.51.3", dev_dependency = True)


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_vhdl: 0.2.0 -> 0.3.0